### PR TITLE
Update syntax.php

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -24,7 +24,7 @@ class syntax_plugin_targetlink extends DokuWiki_Syntax_Plugin {
     }
 
     function connectTo($mode) {
-      $this->Lexer->addSpecialPattern('\[\[target=.*\|.*?\]\](?!\])',$mode,'plugin_targetlink');
+      $this->Lexer->addSpecialPattern('\[\[target=[^\|]*\|.*?\]\](?!\])',$mode,'plugin_targetlink');
       $this->Lexer->addSpecialPattern('\[\[\+tab\|.*?\]\](?!\])',$mode,'plugin_targetlink');
     }
 


### PR DESCRIPTION
regular expression does not match named links

[[target=_blank|:start|Main page]] now works ok

Tested in:
PHP Version => 7.2.5
System => Linux ip-172-16-3-206 4.14.62-70.117.amzn2.x86_64 #1 SMP Fri Aug 10 20:14:53 UTC 2018 x86_64